### PR TITLE
Implement merging nmap service data to HostResult.Port

### DIFF
--- a/v2/pkg/port/port.go
+++ b/v2/pkg/port/port.go
@@ -6,10 +6,21 @@ import (
 	"github.com/projectdiscovery/naabu/v2/pkg/protocol"
 )
 
+type Service struct {
+	Name      string   `json:"name"`
+	Product   string   `json:"product"`
+	ExtraInfo string   `json:"extrainfo"`
+	CPEs      []string `json:"cpes"`
+
+	State string `json:"state"`
+}
+
 type Port struct {
 	Port     int               `json:"port"`
 	Protocol protocol.Protocol `json:"protocol"`
 	TLS      bool              `json:"tls"`
+
+	Service Service `json:"service"`
 }
 
 func (p *Port) String() string {

--- a/v2/pkg/result/results.go
+++ b/v2/pkg/result/results.go
@@ -110,6 +110,33 @@ func (r *Result) SetPorts(ip string, ports []*port.Port) {
 	r.ips[ip] = struct{}{}
 }
 
+// Get port object for (ip, port)
+func (r *Result) GetPort(ip string, port int) *port.Port {
+	r.RLock()
+	defer r.RUnlock()
+
+	for _, ports := range r.ipPorts {
+		for _, p := range ports {
+			if p.Port == port {
+				return p
+			}
+		}
+	}
+	return nil
+}
+
+// Update port object for (ip, port)
+func (r *Result) UpdatePort(ip string, p *port.Port) {
+	r.Lock()
+	defer r.Unlock()
+
+	if _, ok := r.ipPorts[ip]; !ok {
+		r.ipPorts[ip] = make(map[string]*port.Port)
+	}
+
+	r.ipPorts[ip][p.String()] = p
+}
+
 // IPHasPort checks if an ip has a specific port
 func (r *Result) IPHasPort(ip string, p *port.Port) bool {
 	r.RLock()

--- a/v2/pkg/runner/runner.go
+++ b/v2/pkg/runner/runner.go
@@ -326,10 +326,9 @@ func (r *Runner) RunEnumeration() error {
 			r.ConnectVerification()
 		}
 
+		r.handleNmap()
 		r.handleOutput(r.scanner.ScanResults)
-
-		// handle nmap
-		return r.handleNmap()
+		return nil
 	default:
 		showNetworkCapabilities(r.options)
 
@@ -490,9 +489,8 @@ func (r *Runner) RunEnumeration() error {
 		}
 
 		r.handleOutput(r.scanner.ScanResults)
-
-		// handle nmap
-		return r.handleNmap()
+		r.handleNmap()
+		return nil
 	}
 }
 


### PR DESCRIPTION
By default in scan operation, Naabu handles output (onresult, json, csv, file) and then executes nmap with shell if enabled. 

The aim is not to throw out Nmap data to the user's face but to put it proper struct.

Upon analyzing how naabu deals with nmap execution and output, I was looking for ways to include this data, I realized that both `handleOutput` and `handleNmap` methods are using `GetIPsPorts` method which is a getter for the scan data result that has been collected.

The cleanest solution I could think of was to reorder handling nmap and output to handle nmap first because then we don't throw out the data.

in `handleNmap` method I decided to access the overall result, match my IP and port between the nmap and overall result, and update the result with nmap's new data.